### PR TITLE
[Resolves 14] Update to python 3.9

### DIFF
--- a/CloudWatch2S3-additional-account.template
+++ b/CloudWatch2S3-additional-account.template
@@ -173,7 +173,7 @@ Resources:
         Fn::GetAtt:
           - LogSubscriberRole
           - Arn
-      Runtime: python3.6
+      Runtime: python3.9
       Timeout: 300
     Type: AWS::Lambda::Function
   LogSubscriberPermission:

--- a/CloudWatch2S3.template
+++ b/CloudWatch2S3.template
@@ -582,7 +582,7 @@ Resources:
         Fn::GetAtt:
           - LogProcessorRole
           - Arn
-      Runtime: python3.6
+      Runtime: python3.9
       Timeout: 300
     Type: AWS::Lambda::Function
   LogProcessorRole:
@@ -737,7 +737,7 @@ Resources:
         Fn::GetAtt:
           - LogSubscriberRole
           - Arn
-      Runtime: python3.6
+      Runtime: python3.9
       Timeout: 300
     Type: AWS::Lambda::Function
   LogSubscriberPermission:


### PR DESCRIPTION
AWS no longer supports python 3.6 which means this solution cannot even be deployed unless it uses a more updated python version.

This resolves issue #14 